### PR TITLE
Prevent passing NULL to md5

### DIFF
--- a/classes/MockDelegateFunctionBuilder.php
+++ b/classes/MockDelegateFunctionBuilder.php
@@ -56,7 +56,7 @@ class MockDelegateFunctionBuilder
          * If a class with the same signature exists, it is considered equivalent
          * to the generated class.
          */
-        $hash = md5($signatureParameters);
+        $hash = md5(is_string($signatureParameters) ? $signatureParameters : '');
         $this->namespace = __NAMESPACE__ . $hash;
         if (class_exists($this->getFullyQualifiedClassName())) {
             return;


### PR DESCRIPTION
I am getting this error when running tests on PHP 8.1:

`.PHP Deprecated:  md5(): Passing null to parameter #1 ($string) of type string is deprecated in /<PATH>/vendor/php-mock/php-mock-integration/classes/MockDelegateFunctionBuilder.php on line 59`

This PR ensures that only string values are passed to `md5()`
